### PR TITLE
convertFortAmount() Will now Return String

### DIFF
--- a/upload/system/library/payfortFort/classes/Helper.php
+++ b/upload/system/library/payfortFort/classes/Helper.php
@@ -77,7 +77,7 @@ class Payfort_Fort_Helper
             $new_amount = round($amount, $decimal_points);
         }
         $new_amount = $new_amount * (pow(10, $decimal_points));
-        return $new_amount;
+        return (string)$new_amount;
     }
 
     /**


### PR DESCRIPTION
convertFortAmount() will now Send the amount value as String, and The same will be used for Signature Calculation. 
This will resolve the the php bug(7.1.x), which adds Floating point decimal to Integer Values. 
https://bugs.php.net/bug.php?id=72567

The Fort accept Both Integer and String type for Amount, hence it will not impact The Transaction.